### PR TITLE
ci: install missing .NET SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - uses: actions/setup-dotnet@v3
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - uses: actions/setup-dotnet@v3
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -64,6 +66,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - uses: actions/setup-dotnet@v3
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - uses: actions/setup-dotnet@v3
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/src/build/FlashOWare.Tool.Build/Build.cs
+++ b/src/build/FlashOWare.Tool.Build/Build.cs
@@ -20,6 +20,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
         GitHubActionsImage.MacOs12,
         GitHubActionsImage.Ubuntu2204,
         GitHubActionsImage.WindowsServer2022,
+        AutoGenerate = false,
         OnPushBranches = new[] { "main" },
         OnPullRequestBranches = new[] { "main" },
         FetchDepth = 1,
@@ -27,6 +28,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 [GitHubActions(
     "publish",
         GitHubActionsImage.Ubuntu2204,
+        AutoGenerate = false,
         OnPushBranches = new[] { "publish" },
         FetchDepth = 1,
         InvokedTargets = new[] { nameof(Publish) },


### PR DESCRIPTION
Hello Stefan,
current GitHub Actions Runners/Images do not contain the latest .NET 8.0.100 version (e.g. [Windows 2022 template](https://github.com/actions/runner-images/blob/436da67f4bd24acde9d9119870203f9dbbcf3bbe/images/windows/toolsets/toolset-2022.json#L365-L369)).

I added manually the setup of the .NET tools as an action-step to the workflow.
Therefore the automatic generation of the CI and Publish actions are currently disabled.

I tested the [building of the PR at my forked repository](https://github.com/Gh0stWalk3r/FlashOWare.Tool/actions/runs/6915870701) and compared it with your last commit.

Kind regards,
Gregor