### PR TITLE
ci: fix integration tests timing out on Windows

### DIFF
--- a/src/tests/FlashOWare.Tool.Cli.Tests/Extensions/CollectionExtensions.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Extensions/CollectionExtensions.cs
@@ -1,0 +1,12 @@
+namespace FlashOWare.Tool.Cli.Tests.Extensions;
+
+internal static class CollectionExtensions
+{
+    public static void AddRange<T>(this ICollection<T> collection, T[] items)
+    {
+        foreach (T item in items)
+        {
+            collection.Add(item);
+        }
+    }
+}

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/EnvironmentVariables.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/EnvironmentVariables.cs
@@ -1,0 +1,6 @@
+namespace FlashOWare.Tool.Cli.Tests.Hosting;
+
+internal static class EnvironmentVariables
+{
+    public static readonly string GitHubActions = "GITHUB_ACTIONS";
+}

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/TestEnvironment.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/TestEnvironment.cs
@@ -1,0 +1,14 @@
+namespace FlashOWare.Tool.Cli.Tests.Hosting;
+
+internal static class TestEnvironment
+{
+    private static readonly Lazy<bool> s_isContinuousIntegration = new(IsContinuousIntegrationCore);
+
+    public static bool IsContinuousIntegration => s_isContinuousIntegration.Value;
+
+    private static bool IsContinuousIntegrationCore()
+    {
+        string? value = Environment.GetEnvironmentVariable(EnvironmentVariables.GitHubActions);
+        return value == bool.TrueString;
+    }
+}

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/TestEnvironment.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Hosting/TestEnvironment.cs
@@ -9,6 +9,6 @@ internal static class TestEnvironment
     private static bool IsContinuousIntegrationCore()
     {
         string? value = Environment.GetEnvironmentVariable(EnvironmentVariables.GitHubActions);
-        return value == bool.TrueString;
+        return value == "true";
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
@@ -3,6 +3,7 @@ using FlashOWare.Tool.Cli.Tests.MSBuild;
 using FlashOWare.Tool.Cli.Tests.Sdk;
 using FlashOWare.Tool.Cli.Tests.Testing;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Diagnostics;
 using Xunit.Abstractions;
 
 namespace FlashOWare.Tool.Cli.Tests.Interceptors;
@@ -94,7 +95,10 @@ public class InterceptorLocatorTests : IntegrationTests
                 """, "MyEnum.cs")
             .AddPackage(Packages.FlashOWare_Generators)
             .Initialize(ProjectKind.SdkStyle, TargetFramework.Net80, LanguageVersion.CSharp12);
+        Stopwatch stopwatch = Stopwatch.StartNew();
         await DotNet.RestoreAsync(project.File);
+        stopwatch.Stop();
+        System.Console.WriteLine($"DotNet.RestoreAsync: {stopwatch.Elapsed}");
         //Act
         await (option is null
             ? RunAsync("interceptor", "list")
@@ -128,7 +132,10 @@ public class InterceptorLocatorTests : IntegrationTests
         }
 
         //Arrange
+        Stopwatch stopwatch = Stopwatch.StartNew();
         var project = await DotNet.NewAsync(DotNetNewTemplate.AspNetCoreWebApiNativeAot);
+        stopwatch.Stop();
+        System.Console.WriteLine($"DotNet.NewAsync: {stopwatch.Elapsed}");
         //Act
         await RunAsync("interceptor", "list", option);
         //Assert

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
@@ -133,7 +133,7 @@ public class InterceptorLocatorTests : IntegrationTests
 
         //Arrange
         Stopwatch stopwatch = Stopwatch.StartNew();
-        var project = await DotNet.NewAsync(DotNetNewTemplate.AspNetCoreWebApiNativeAot);
+        var project = await DotNet.NewAsync(DotNetNewTemplate.AspNetCoreWebApiNativeAot, true);
         stopwatch.Stop();
         System.Console.WriteLine($"DotNet.NewAsync: {stopwatch.Elapsed}");
         //Act

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
@@ -3,7 +3,6 @@ using FlashOWare.Tool.Cli.Tests.MSBuild;
 using FlashOWare.Tool.Cli.Tests.Sdk;
 using FlashOWare.Tool.Cli.Tests.Testing;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Diagnostics;
 using Xunit.Abstractions;
 
 namespace FlashOWare.Tool.Cli.Tests.Interceptors;
@@ -95,10 +94,7 @@ public class InterceptorLocatorTests : IntegrationTests
                 """, "MyEnum.cs")
             .AddPackage(Packages.FlashOWare_Generators)
             .Initialize(ProjectKind.SdkStyle, TargetFramework.Net80, LanguageVersion.CSharp12);
-        Stopwatch stopwatch = Stopwatch.StartNew();
         await DotNet.SynchronizedRestoreAsync(project.File);
-        stopwatch.Stop();
-        System.Console.WriteLine($"DotNet.RestoreAsync: {stopwatch.Elapsed}");
         //Act
         await (option is null
             ? RunAsync("interceptor", "list")
@@ -132,10 +128,7 @@ public class InterceptorLocatorTests : IntegrationTests
         }
 
         //Arrange
-        Stopwatch stopwatch = Stopwatch.StartNew();
         var project = await DotNet.NewAsync(DotNetNewTemplate.AspNetCoreWebApiNativeAot, true);
-        stopwatch.Stop();
-        System.Console.WriteLine($"DotNet.NewAsync: {stopwatch.Elapsed}");
         //Act
         await RunAsync("interceptor", "list", option);
         //Assert

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
@@ -94,7 +94,7 @@ public class InterceptorLocatorTests : IntegrationTests
                 """, "MyEnum.cs")
             .AddPackage(Packages.FlashOWare_Generators)
             .Initialize(ProjectKind.SdkStyle, TargetFramework.Net80, LanguageVersion.CSharp12);
-        await DotNet.SynchronizedRestoreAsync(project.File);
+        await DotNet.RestoreAsync(project.File);
         //Act
         await (option is null
             ? RunAsync("interceptor", "list")

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Interceptors/InterceptorLocatorTests.cs
@@ -96,7 +96,7 @@ public class InterceptorLocatorTests : IntegrationTests
             .AddPackage(Packages.FlashOWare_Generators)
             .Initialize(ProjectKind.SdkStyle, TargetFramework.Net80, LanguageVersion.CSharp12);
         Stopwatch stopwatch = Stopwatch.StartNew();
-        await DotNet.RestoreAsync(project.File);
+        await DotNet.SynchronizedRestoreAsync(project.File);
         stopwatch.Stop();
         System.Console.WriteLine($"DotNet.RestoreAsync: {stopwatch.Elapsed}");
         //Act

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -1,4 +1,5 @@
 using FlashOWare.Tool.Cli.Tests.Diagnostics;
+using FlashOWare.Tool.Cli.Tests.Hosting;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -31,7 +32,10 @@ public partial class DotNet
 
         using Process process = StartProcess("dotnet", ["new", "webapiaot", "--name", project, "--output", _directory.FullName, "--language", "C#", "--framework", "net8.0", "--exclude-launch-settings"], options);
 
-        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(30));
+        TimeSpan timeout = OperatingSystem.IsWindows() && TestEnvironment.IsContinuousIntegration
+            ? TimeSpan.FromSeconds(30)
+            : TimeSpan.FromSeconds(10);
+        await process.WaitForSuccessfulExitAsync(timeout);
 
         return project;
     }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -14,9 +14,9 @@ public partial class DotNet
         return NewAsync(template, false);
     }
 
-    internal Task<string> NewAsync(DotNetNewTemplate template, bool norestore)
+    internal Task<string> NewAsync(DotNetNewTemplate template, bool noRestore)
     {
-        DotNetCliOptions options = norestore ? s_noRestore : DotNetCliOptions.None;
+        DotNetCliOptions options = noRestore ? s_noRestore : DotNetCliOptions.None;
 
         return template switch
         {

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -31,7 +31,7 @@ public partial class DotNet
 
         using Process process = StartProcess("dotnet", ["new", "webapiaot", "--name", project, "--output", _directory.FullName, "--language", "C#", "--framework", "net8.0", "--exclude-launch-settings"], options);
 
-        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(60));
+        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(30));
 
         return project;
     }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -39,7 +39,7 @@ public partial class DotNet
 
     private async Task<string> SynchronizedNewAspNetCoreWebApiNativeAotAsync(DotNetCliOptions options)
     {
-        await s_newMutex.WaitAsync();
+        await s_synchronizationMutex.WaitAsync();
 
         try
         {
@@ -47,7 +47,7 @@ public partial class DotNet
         }
         finally
         {
-            _ = s_newMutex.Release();
+            _ = s_synchronizationMutex.Release();
         }
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -7,7 +7,6 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 public partial class DotNet
 {
     private static readonly DotNetCliOptions s_noRestore = new() { NoRestore = true };
-    private static readonly SemaphoreSlim s_newMutex = new(1, 1);
 
     internal Task<string> NewAsync(DotNetNewTemplate template)
     {
@@ -21,7 +20,7 @@ public partial class DotNet
         return template switch
         {
             DotNetNewTemplate.Unspecified => throw new InvalidOperationException("Template not specified."),
-            DotNetNewTemplate.AspNetCoreWebApiNativeAot => SynchronizedNewAspNetCoreWebApiNativeAotAsync(options),
+            DotNetNewTemplate.AspNetCoreWebApiNativeAot => NewAspNetCoreWebApiNativeAotAsync(options),
             _ => throw new InvalidEnumArgumentException(nameof(template), (int)template, typeof(DotNetNewTemplate)),
         };
     }
@@ -35,19 +34,5 @@ public partial class DotNet
         await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(60));
 
         return project;
-    }
-
-    private async Task<string> SynchronizedNewAspNetCoreWebApiNativeAotAsync(DotNetCliOptions options)
-    {
-        await s_synchronizationMutex.WaitAsync();
-
-        try
-        {
-            return await NewAspNetCoreWebApiNativeAotAsync(options);
-        }
-        finally
-        {
-            _ = s_synchronizationMutex.Release();
-        }
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -32,7 +32,7 @@ public partial class DotNet
 
         using Process process = StartProcess("dotnet", ["new", "webapiaot", "--name", project, "--output", _directory.FullName, "--language", "C#", "--framework", "net8.0", "--exclude-launch-settings"], options);
 
-        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(15));
+        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(60));
 
         return project;
     }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.New.cs
@@ -6,21 +6,30 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 
 public partial class DotNet
 {
+    private static readonly DotNetCliOptions s_noRestore = new() { NoRestore = true };
+
     internal Task<string> NewAsync(DotNetNewTemplate template)
     {
+        return NewAsync(template, false);
+    }
+
+    internal Task<string> NewAsync(DotNetNewTemplate template, bool norestore)
+    {
+        DotNetCliOptions options = norestore ? s_noRestore : DotNetCliOptions.None;
+
         return template switch
         {
             DotNetNewTemplate.Unspecified => throw new InvalidOperationException("Template not specified."),
-            DotNetNewTemplate.AspNetCoreWebApiNativeAot => NewAspNetCoreWebApiNativeAotAsync(),
+            DotNetNewTemplate.AspNetCoreWebApiNativeAot => NewAspNetCoreWebApiNativeAotAsync(options),
             _ => throw new InvalidEnumArgumentException(nameof(template), (int)template, typeof(DotNetNewTemplate)),
         };
     }
 
-    internal async Task<string> NewAspNetCoreWebApiNativeAotAsync()
+    private async Task<string> NewAspNetCoreWebApiNativeAotAsync(DotNetCliOptions options)
     {
         string project = "WebApiAotProject";
 
-        using Process process = StartProcess("dotnet", "new", "webapiaot", "--name", project, "--output", _directory.FullName, "--language", "C#", "--framework", "net8.0", "--exclude-launch-settings");
+        using Process process = StartProcess("dotnet", ["new", "webapiaot", "--name", project, "--output", _directory.FullName, "--language", "C#", "--framework", "net8.0", "--exclude-launch-settings"], options);
 
         await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(15));
 

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
@@ -5,26 +5,10 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 
 public partial class DotNet
 {
-    private static readonly SemaphoreSlim s_restoreMutex = new(1, 1);
-
     internal async Task RestoreAsync(FileInfo project)
     {
         using Process process = StartProcess("dotnet", "restore", project.FullName);
 
         await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(15));
-    }
-
-    internal async Task SynchronizedRestoreAsync(FileInfo project)
-    {
-        await s_synchronizationMutex.WaitAsync();
-
-        try
-        {
-            await RestoreAsync(project);
-        }
-        finally
-        {
-            _ = s_synchronizationMutex.Release();
-        }
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
@@ -1,4 +1,5 @@
 using FlashOWare.Tool.Cli.Tests.Diagnostics;
+using FlashOWare.Tool.Cli.Tests.Hosting;
 using System.Diagnostics;
 
 namespace FlashOWare.Tool.Cli.Tests.Sdk;
@@ -9,6 +10,9 @@ public partial class DotNet
     {
         using Process process = StartProcess("dotnet", "restore", project.FullName);
 
-        await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(15));
+        TimeSpan timeout = OperatingSystem.IsWindows() && TestEnvironment.IsContinuousIntegration
+            ? TimeSpan.FromSeconds(15)
+            : TimeSpan.FromSeconds(05);
+        await process.WaitForSuccessfulExitAsync(timeout);
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
@@ -5,10 +5,26 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 
 public partial class DotNet
 {
+    private static readonly SemaphoreSlim s_restoreMutex = new(1, 1);
+
     internal async Task RestoreAsync(FileInfo project)
     {
         using Process process = StartProcess("dotnet", "restore", project.FullName);
 
         await process.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(15));
+    }
+
+    internal async Task SynchronizedRestoreAsync(FileInfo project)
+    {
+        await s_restoreMutex.WaitAsync();
+
+        try
+        {
+            await RestoreAsync(project);
+        }
+        finally
+        {
+            _ = s_restoreMutex.Release();
+        }
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.Restore.cs
@@ -16,7 +16,7 @@ public partial class DotNet
 
     internal async Task SynchronizedRestoreAsync(FileInfo project)
     {
-        await s_restoreMutex.WaitAsync();
+        await s_synchronizationMutex.WaitAsync();
 
         try
         {
@@ -24,7 +24,7 @@ public partial class DotNet
         }
         finally
         {
-            _ = s_restoreMutex.Release();
+            _ = s_synchronizationMutex.Release();
         }
     }
 }

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
@@ -5,8 +5,6 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 
 public sealed partial class DotNet
 {
-    private static readonly SemaphoreSlim s_synchronizationMutex = new(1, 1);
-
     private readonly DirectoryInfo _directory;
 
     public DotNet(DirectoryInfo directory)

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
@@ -1,4 +1,4 @@
-using NuGet.Packaging;
+using FlashOWare.Tool.Cli.Tests.Extensions;
 using System.Diagnostics;
 
 namespace FlashOWare.Tool.Cli.Tests.Sdk;
@@ -14,17 +14,26 @@ public sealed partial class DotNet
 
     private Process StartProcess(string fileName, params string[] arguments)
     {
+        return StartProcess(fileName, arguments, DotNetCliOptions.None);
+    }
+
+    private Process StartProcess(string fileName, string[] arguments, DotNetCliOptions options)
+    {
+#if NET8_0_OR_GREATER
+        ProcessStartInfo startInfo = new(fileName, arguments)
+#else
         ProcessStartInfo startInfo = new(fileName)
+#endif
         {
             WorkingDirectory = _directory.FullName,
             CreateNoWindow = true,
             RedirectStandardOutput = true,
         };
 
-        if (arguments.Length != 0)
-        {
-            startInfo.ArgumentList.AddRange(arguments);
-        }
+#if !NET8_0_OR_GREATER
+        startInfo.ArgumentList.AddRange(arguments);
+#endif
+        options.AddTo(startInfo.ArgumentList);
 
         var process = Process.Start(startInfo);
 

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNet.cs
@@ -5,6 +5,8 @@ namespace FlashOWare.Tool.Cli.Tests.Sdk;
 
 public sealed partial class DotNet
 {
+    private static readonly SemaphoreSlim s_synchronizationMutex = new(1, 1);
+
     private readonly DirectoryInfo _directory;
 
     public DotNet(DirectoryInfo directory)

--- a/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNetCliOptions.cs
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/Sdk/DotNetCliOptions.cs
@@ -1,0 +1,20 @@
+namespace FlashOWare.Tool.Cli.Tests.Sdk;
+
+internal sealed class DotNetCliOptions
+{
+    public static DotNetCliOptions None { get; } = new();
+
+    public DotNetCliOptions()
+    {
+    }
+
+    public bool NoRestore { get; init; }
+
+    public void AddTo(ICollection<string> collection)
+    {
+        if (NoRestore)
+        {
+            collection.Add("--no-restore");
+        }
+    }
+}


### PR DESCRIPTION
Integration tests that invoke commands from the .NET SDK with a Timeout are very likely throwing on GitHub-hosted Windows runners.