### PR TITLE
ci: install required .NET SDKs explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -50,6 +55,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -67,6 +77,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/src/tests/FlashOWare.Tool.Cli.Tests/FlashOWare.Tool.Cli.Tests.csproj
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/FlashOWare.Tool.Cli.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
-    <PackageReference Include="NuGet.Packaging" Version="[6.*,6.12.0)" />
+    <PackageReference Include="NuGet.Packaging" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/FlashOWare.Tool.Cli.Tests/FlashOWare.Tool.Cli.Tests.csproj
+++ b/src/tests/FlashOWare.Tool.Cli.Tests/FlashOWare.Tool.Cli.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.8.0" />
+    <PackageReference Include="NuGet.Packaging" Version="[6.*,6.12.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## CI/CD workflows: setup-dotnet action
With PR #96 (postcondition: _standard error output stream_ is empty) we require not only the _.NET 8.0 SDK_ to be installed locally, but also the _reference assemblies_ of other frameworks that our tests target (currently _.NET 7.0_ & _.NET 6.0_).
On my machine I had only the _.NET 8.0 SDK_ and the _.NET Core 3.1 SDK_ installed, and the new postcondition failed:
```
[Failure] Msbuild failed when processing the file '{..}\TestProject.csproj' with message {..}: The reference assemblies for ".NETFramework,Version=v6.0" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.
```
In order to not rely on the preinstalled software of the GitHub-hosted runners, and mirror my current local setup, let's install the dependencies explicitly.

As a side effect, we are also installing the latest _.NET SDK_ as per `global.json`.
Previously the exact `version` was installed, disregarding the `rollForward`.
From Job _ubuntu-22_04_:
```
dotnet-install: Attempting to download using primary link https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-linux-x64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-linux-x64.tar.gz
dotnet-install: Installed version is 8.0.100
dotnet-install: Adding to current process PATH: `/usr/share/dotnet`. Note: This change will be visible only when sourcing script.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
```
## Version of NuGet.Packaging for integration tests
However, using the latest .NET SDK (currently _SDK 8.0.204_) also requires updating the package `NuGet.Packaging` to a compatible version (e.g. `v6.9.1`) for `interceptor list` integration tests to succeed. It would be tedious to keep the version of `NuGet.Packaging` in sync with the latest .NET SDK manually.
i.e.
| .NET SDK | NuGet.Packaging |
| -------- | --------------- |
| 8.0.1nn  | 6.8.0           |
| 8.0.2nn  | 6.9.1           |
| 8.0.3nn  | 6.10.*          |
| 8.0.4nn  | 6.11.*          |

Where `6.7.1` is compatible with the .NET SDK `7.0.4nn`,
and `6.12.*` will be compatible with the upcoming .NET SDK `9.0.100` (unless Microsoft will release a new _major_ version of _Visual Studio_ for _.NET 9.0_, so `18.0` instead of `17.12`, in which case the _major_ version of the NuGet packages will also be incremented to `7.0.*`).

So I'm proposing the version range `[6.*,6.12.0)`, where open/close brackets `[]` are _inclusive_, open/close parentheses `()` are _exclusive_, and the asterisk `*` resolves to the _highest_ version available, therefore resolving to the latest compatible version for all feature bands within the .NET 8.0 release cycle.

This way developers may have any non-preview .NET 8.0 SDK installed, in accordance with our `global.json`, and still be able to successfully run the `interceptor list` integration tests locally. And CI/CD should be fine selecting the latest _patch_ version of the .NET 8.0 SDK and also succeed.

See [Package versioning](https://learn.microsoft.com/nuget/concepts/package-versioning)
See [global.json overview](https://learn.microsoft.com/dotnet/core/tools/global-json)
Also ... I think this is the first time I am writing more documentation than actual code 😉.